### PR TITLE
Fix broken Docker build

### DIFF
--- a/data-engineer-airflow-challenge/docker/Dockerfile
+++ b/data-engineer-airflow-challenge/docker/Dockerfile
@@ -56,6 +56,7 @@ RUN set -ex \
     && pip install pyOpenSSL \
     && pip install ndg-httpsclient \
     && pip install pyasn1 \
+    && pip install Werkzeug==0.15.4 \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get clean \
     && rm -rf \


### PR DESCRIPTION
This doesn't feel like it is "part of the challenge" considering it fails during the first part of the "Quick Start" section. 

As of March 3 2020 Werkzeug was upgraded to 1.0.0, this broke multiple Flask dependencies. 

Force Werkzeug version to 0.15.4 for the challenge

fwiw; This is resolved in Airflow 1.10